### PR TITLE
Chore: Remove traces of the btpLayout Feature Toggle (DXPFRAME-1887)

### DIFF
--- a/projects/lib/src/lib/services/luigi-config/lifecycle-hooks-config.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-config/lifecycle-hooks-config.service.spec.ts
@@ -90,15 +90,12 @@ describe('LifecycleHooksConfigService', () => {
     });
 
     describe('luigiAfterInit', () => {
-      it('should resetLuigi once the feature toggle is set to have btpLayout', async () => {
+      it('should always resetLuigi', async () => {
         luigiCoreServiceMock.isFeatureToggleActive.mockReturnValue(true);
         const config = service.getLifecycleHooksConfig({} as any);
 
         await config.luigiAfterInit();
 
-        expect(luigiCoreServiceMock.isFeatureToggleActive).toHaveBeenCalledWith(
-          'btpLayout'
-        );
         expect(luigiCoreServiceMock.resetLuigi).toHaveBeenCalled();
       });
 

--- a/projects/lib/src/lib/services/luigi-config/lifecycle-hooks-config.service.ts
+++ b/projects/lib/src/lib/services/luigi-config/lifecycle-hooks-config.service.ts
@@ -60,9 +60,8 @@ export class LifecycleHooksConfigService {
 
         this.luigiCoreService.ux().hideAppLoadingIndicator();
         this.luigiCoreService.setConfig(config);
-        if (this.luigiCoreService.isFeatureToggleActive('btpLayout')) {
-          this.luigiCoreService.resetLuigi();
-        }
+        this.luigiCoreService.resetLuigi();
+        
         this.addLocalDevelopmentModeOnIndicator();
       },
     };


### PR DESCRIPTION
Since we remove the feature toggle and deploy the new layout by default, checking for extra conditions is not necessary anymore.

🚨 DO NOT MERGE UNTIL https://github.tools.sap/dxp/appframe-stack/pull/2245 HAS REACHED PROD 🚨

Refers to [DXPFRAME-1887](https://jira.tools.sap/browse/DXPFRAME-1887)