### PR TITLE
bug: fix local nodes

### DIFF
--- a/projects/lib/src/lib/models/luigi-context.ts
+++ b/projects/lib/src/lib/models/luigi-context.ts
@@ -34,4 +34,5 @@ export interface NodeContext extends LuigiGlobalContext {
     additionalContext?: Record<string, any>;
   };
   translationTable?: Record<string, any>;
+  serviceProviderConfig?: Record<string, any>;
 }

--- a/projects/lib/src/lib/portal-providers.spec.ts
+++ b/projects/lib/src/lib/portal-providers.spec.ts
@@ -1,26 +1,9 @@
-import { providePortal, PortalOptions } from './portal-providers';
-import * as core from '@angular/core';
-import * as http from '@angular/common/http';
 import * as tokens from './injection-tokens';
-import {
-  AppSwitcherConfigService,
-  CustomGlobalNodesService,
-  CustomMessageListener,
-  GlobalSearchConfigService,
-  LocalConfigurationServiceImpl,
-  LuigiAuthEventsCallbacksService,
-  LuigiBreadcrumb,
-  LuigiBreadcrumbConfigService,
-  LuigiExtendedGlobalContextConfigService,
-  CustomNodeProcessingService,
-  NodeChangeHookConfigService,
-  StaticSettingsConfigService,
-  ThemingService,
-  UserProfileConfigService,
-} from './services';
+import { PortalOptions, providePortal } from './portal-providers';
+import { CustomMessageListener } from './services';
 import * as services from './services';
-import { Context } from '@luigi-project/client';
-import { LuigiNode } from './models';
+import * as http from '@angular/common/http';
+import * as core from '@angular/core';
 
 class MockCustomListener1 implements CustomMessageListener {
   messageId(): string {
@@ -71,7 +54,7 @@ describe('Provide Portal', () => {
     const customListenerProviders = providersArg.filter(
       (provider: any) =>
         provider?.provide ===
-        tokens.LUIGI_CUSTOM_MESSAGE_LISTENERS_INJECTION_TOKEN
+        tokens.LUIGI_CUSTOM_MESSAGE_LISTENERS_INJECTION_TOKEN,
     );
 
     expect(customListenerProviders).toHaveLength(2);
@@ -95,7 +78,7 @@ describe('Provide Portal', () => {
     const customListenerProviders = providersArg.filter(
       (provider: any) =>
         provider?.provide ===
-        tokens.LUIGI_CUSTOM_MESSAGE_LISTENERS_INJECTION_TOKEN
+        tokens.LUIGI_CUSTOM_MESSAGE_LISTENERS_INJECTION_TOKEN,
     );
 
     expect(customListenerProviders).toHaveLength(0);
@@ -105,11 +88,6 @@ describe('Provide Portal', () => {
     providePortal({});
 
     const providersArg = mockMakeEnvironmentProviders.mock.calls[0][0];
-
-    expect(providersArg).toContainEqual({
-      provide: tokens.LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
-      useClass: LocalConfigurationServiceImpl,
-    });
 
     expect(providersArg).toContainEqual({
       provide: tokens.LUIGI_NODE_CHANGE_HOOK_SERVICE_INJECTION_TOKEN,
@@ -131,11 +109,17 @@ describe('Provide Portal', () => {
       luigiBreadcrumbConfigService: {} as any,
       themingService: {} as any,
       errorComponentConfig: { '404': {} } as any,
+      localConfigurationService: {} as any,
     };
 
     providePortal(options);
 
     const providersArg = mockMakeEnvironmentProviders.mock.calls[0][0];
+
+    expect(providersArg).toContainEqual({
+      provide: tokens.LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
+      useClass: {},
+    });
 
     expect(providersArg).toContainEqual({
       provide: tokens.ERROR_COMPONENT_CONFIG,
@@ -206,7 +190,7 @@ describe('Provide Portal', () => {
 
     expect(providersArg).toContainEqual(http.provideHttpClient());
     expect(providersArg).toContainEqual(
-      core.provideZoneChangeDetection({ eventCoalescing: true })
+      core.provideZoneChangeDetection({ eventCoalescing: true }),
     );
   });
 });

--- a/projects/lib/src/lib/portal-providers.ts
+++ b/projects/lib/src/lib/portal-providers.ts
@@ -11,9 +11,9 @@ import {
   LUIGI_AUTH_EVENTS_CALLBACKS_SERVICE_INJECTION_TOKEN,
   LUIGI_BREADCRUMB_CONFIG_SERVICE_INJECTION_TOKEN,
   LUIGI_CUSTOM_MESSAGE_LISTENERS_INJECTION_TOKEN,
+  LUIGI_CUSTOM_NODE_PROCESSING_SERVICE_INJECTION_TOKEN,
   LUIGI_EXTENDED_GLOBAL_CONTEXT_CONFIG_SERVICE_INJECTION_TOKEN,
   LUIGI_GLOBAL_SEARCH_CONFIG_SERVICE_INJECTION_TOKEN,
-  LUIGI_CUSTOM_NODE_PROCESSING_SERVICE_INJECTION_TOKEN,
   LUIGI_NODES_CUSTOM_GLOBAL_SERVICE_INJECTION_TOKEN,
   LUIGI_NODE_CHANGE_HOOK_SERVICE_INJECTION_TOKEN,
   LUIGI_STATIC_SETTINGS_CONFIG_SERVICE_INJECTION_TOKEN,
@@ -27,13 +27,13 @@ import {
   AppSwitcherConfigServiceImpl,
   CustomGlobalNodesService,
   CustomMessageListener,
+  CustomNodeProcessingService,
   GlobalSearchConfigService,
   LocalConfigurationService,
   LocalConfigurationServiceImpl,
   LuigiAuthEventsCallbacksService,
   LuigiBreadcrumbConfigService,
   LuigiExtendedGlobalContextConfigService,
-  CustomNodeProcessingService,
   NodeChangeHookConfigService,
   NodeChangeHookConfigServiceImpl,
   StaticSettingsConfigService,
@@ -142,16 +142,18 @@ const addOptionalProviders = (
         options.nodeChangeHookConfigService || NodeChangeHookConfigServiceImpl,
     },
     {
-      provide: LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
-      useClass:
-        options.localConfigurationService || LocalConfigurationServiceImpl,
-    },
-    {
       provide: LUIGI_USER_PROFILE_CONFIG_SERVICE_INJECTION_TOKEN,
       useClass:
         options.userProfileConfigService || UserProfileConfigServiceImpl,
     },
   );
+
+  if (options.localConfigurationService) {
+    providers.push({
+      provide: LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
+      useClass: options.localConfigurationService,
+    });
+  }
 
   if (options.staticSettingsConfigService) {
     providers.push({

--- a/projects/lib/src/lib/services/luigi-config/node-change-hook-config.service.ts
+++ b/projects/lib/src/lib/services/luigi-config/node-change-hook-config.service.ts
@@ -39,7 +39,7 @@ export class NodeChangeHookConfigServiceImpl
 
     const org = this.luigiCoreService.getGlobalContext().organization;
     const kcpPath =
-      nextNode.context.kcpPath || `${kcpRootOrgsPath}:${org}${entityKcpPath}`;
+      nextNode.context?.kcpPath || `${kcpRootOrgsPath}:${org}${entityKcpPath}`;
     this.gatewayService.updateCrdGatewayUrlWithEntityPath(kcpPath);
   }
 }

--- a/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.spec.ts
@@ -1,9 +1,13 @@
+import { LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN } from '../../injection-tokens';
 import { ContentConfiguration, LuigiNode } from '../../models';
 import { I18nService } from '../i18n.service';
 import { LuigiCoreService } from '../luigi-core.service';
 import { LocalNodesService } from '../portal';
 import { localDevelopmentSettingsLocalStorage } from '../storage-service';
-import { LocalConfigurationServiceImpl } from './local-configuration.service';
+import {
+  LocalConfigurationService,
+  LocalConfigurationServiceImpl,
+} from './local-configuration.service';
 import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { MockProxy, mock } from 'jest-mock-extended';
@@ -15,9 +19,11 @@ describe('LocalConfigurationServiceImpl', () => {
   let httpClient: HttpClient;
   let luigiDataConfigServiceMock: MockProxy<LocalNodesService>;
   let i18nServiceMock: jest.Mocked<I18nService>;
+  let customLocalConfigurationServiceMock: jest.Mocked<LocalConfigurationService>;
 
   beforeEach(() => {
     i18nServiceMock = mock();
+    customLocalConfigurationServiceMock = mock();
     localDevelopmentSettingsLocalStorage.read = jest.fn();
     luigiDataConfigServiceMock = mock<LocalNodesService>();
     TestBed.configureTestingModule({
@@ -25,6 +31,10 @@ describe('LocalConfigurationServiceImpl', () => {
         {
           provide: LocalNodesService,
           useValue: luigiDataConfigServiceMock,
+        },
+        {
+          provide: LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
+          useValue: customLocalConfigurationServiceMock,
         },
         { provide: I18nService, useValue: i18nServiceMock },
         provideHttpClient(),
@@ -362,6 +372,9 @@ describe('LocalConfigurationServiceImpl', () => {
       const localNodes = await service.getLocalNodes();
 
       expect(localNodes).toEqual([]);
+      expect(
+        customLocalConfigurationServiceMock.getLocalNodes,
+      ).toHaveBeenCalled();
     });
 
     it('should return an empty array for a dev environment if the request fails', async () => {

--- a/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
@@ -37,7 +37,9 @@ export class LocalConfigurationServiceImpl {
       localDevelopmentSettingsLocalStorage.read();
 
     if (!localDevelopmentSettings?.isActive) {
-      return (await this.customLocalConfigurationService.getLocalNodes()) || [];
+      return (
+        (await this.customLocalConfigurationService?.getLocalNodes()) || []
+      );
     }
 
     this.addLocalDevelopmentModeOnIndicator();

--- a/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
@@ -1,3 +1,4 @@
+import { LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN } from '../../injection-tokens';
 import {
   ContentConfiguration,
   LocalDevelopmentSettings,
@@ -14,23 +15,21 @@ import { merge } from 'lodash';
 import { lastValueFrom } from 'rxjs';
 
 export interface LocalConfigurationService {
-  replaceServerNodesWithLocalOnes(
-    serverLuigiNodes: LuigiNode[],
-    currentEntities: string[],
-  ): Promise<LuigiNode[]>;
   getLocalNodes(): Promise<LuigiNode[]>;
 }
 
 @Injectable({
   providedIn: 'root',
 })
-export class LocalConfigurationServiceImpl
-  implements LocalConfigurationService
-{
+export class LocalConfigurationServiceImpl {
   private http = inject(HttpClient);
   private luigiConfigService = inject(LocalNodesService);
   private i18nService = inject(I18nService);
   private luigiCoreService = inject(LuigiCoreService);
+  private customLocalConfigurationService = inject<LocalConfigurationService>(
+    LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN as any,
+    { optional: true },
+  );
   private cachedLocalNodes: LuigiNode[];
 
   public async getLocalNodes(): Promise<LuigiNode[]> {
@@ -38,7 +37,7 @@ export class LocalConfigurationServiceImpl
       localDevelopmentSettingsLocalStorage.read();
 
     if (!localDevelopmentSettings?.isActive) {
-      return [];
+      return (await this.customLocalConfigurationService.getLocalNodes()) || [];
     }
 
     this.addLocalDevelopmentModeOnIndicator();

--- a/projects/lib/src/lib/services/luigi-nodes/luigi-nodes.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/luigi-nodes.service.spec.ts
@@ -37,7 +37,7 @@ describe('LuigiNodesService', () => {
     TestBed.configureTestingModule({
       providers: [
         {
-          provide: LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
+          provide: LocalConfigurationServiceImpl,
           useValue: localConfigurationServiceMock,
         },
         {

--- a/projects/lib/src/lib/services/luigi-nodes/luigi-nodes.service.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/luigi-nodes.service.ts
@@ -1,7 +1,4 @@
-import {
-  ERROR_COMPONENT_CONFIG,
-  LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN,
-} from '../../injection-tokens';
+import { ERROR_COMPONENT_CONFIG } from '../../injection-tokens';
 import {
   EntityConfig,
   EntityDefinition,
@@ -13,7 +10,7 @@ import {
 } from '../../models';
 import { I18nService } from '../i18n.service';
 import { ConfigService } from '../portal';
-import { LocalConfigurationService } from './local-configuration.service';
+import { LocalConfigurationServiceImpl } from './local-configuration.service';
 import { Injectable, inject } from '@angular/core';
 
 @Injectable({
@@ -22,14 +19,12 @@ import { Injectable, inject } from '@angular/core';
 export class LuigiNodesService {
   private i18nService = inject(I18nService);
   private configService = inject(ConfigService);
+  private localConfigurationService = inject(LocalConfigurationServiceImpl);
   private errorComponentConfig = inject<Record<string, ErrorComponentConfig>>(
     ERROR_COMPONENT_CONFIG as any,
     {
       optional: true,
     },
-  );
-  private localConfigurationService = inject<LocalConfigurationService>(
-    LOCAL_CONFIGURATION_SERVICE_INJECTION_TOKEN as any,
   );
 
   private getChildrenByEntity(


### PR DESCRIPTION
Fixing the way local nodes processing is handled, removing the duplicated processing on the client site, having now only one place.