### PR TITLE
chore: update groups

### DIFF
--- a/docs/readme-generic-ui.md
+++ b/docs/readme-generic-ui.md
@@ -60,7 +60,7 @@ Below is an example content-configuration for an accounts node using the generic
           },
           "context": {
             "resourceDefinition": {
-              "group": "core.openmfp.org",
+              "group": "core.platform-mesh.io",
               "plural": "accounts",
               "singular": "account",
               "kind": "Account",
@@ -196,7 +196,7 @@ In case the detail view is an independent node provide context data:
  {
   "context": {
     "resourceDefinition": {
-      "group": "core.openmfp.org",
+      "group": "core.platform-mesh.io",
       "plural": "accounts",
       "singular": "account",
       "kind": "Account",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@luigi-project/client": "^2.21.3",
     "@luigi-project/client-support-angular": "^2.21.3",
     "@luigi-project/plugin-auth-oauth2": "^2.21.3",
-    "@ui5/webcomponents-ngx": "0.4.8",
+    "@ui5/webcomponents-ngx": "^0.4.8",
     "apollo-angular": "^7.0.0 || ^8.0.0 || ^10.0.0",
     "gql-query-builder": "^3.8.0",
     "graphql": "16.10.0 || ^17.0.0 || ^16.10.0",

--- a/projects/lib/src/lib/models/luigi-context.ts
+++ b/projects/lib/src/lib/models/luigi-context.ts
@@ -17,6 +17,7 @@ export interface LuigiGlobalContext extends Record<string, any> {
   userEmail: string;
   token: string;
   organization: string;
+  portalBaseUrl: string;
 }
 
 export interface NodeContext extends LuigiGlobalContext {

--- a/projects/lib/src/lib/services/luigi-config/navigation-global-context-config.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-config/navigation-global-context-config.service.spec.ts
@@ -6,7 +6,6 @@ import { NavigationGlobalContextConfigService } from './navigation-global-contex
 import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { mock } from 'jest-mock-extended';
-import { UserInfo } from 'node:os';
 
 describe('NavigationGlobalContextConfigService', () => {
   let navigationGlobalContextConfigService: NavigationGlobalContextConfigService;
@@ -38,6 +37,9 @@ describe('NavigationGlobalContextConfigService', () => {
     navigationGlobalContextConfigService = TestBed.inject(
       NavigationGlobalContextConfigService,
     );
+
+    delete window.location;
+    window.location = { origin: 'https://example.com' } as any;
   });
 
   it('should be created', () => {
@@ -87,6 +89,7 @@ describe('NavigationGlobalContextConfigService', () => {
       expect(result).toEqual({
         ...mockExtendedContext,
         portalContext: mockPortalConfig.portalContext,
+        portalBaseUrl: 'https://example.com',
         userId: 'test-user',
         userEmail: 'user@test.com',
         token: 'test-token',
@@ -135,6 +138,7 @@ describe('NavigationGlobalContextConfigService', () => {
 
       expect(result).toEqual({
         portalContext: mockPortalConfig.portalContext,
+        portalBaseUrl: 'https://example.com',
         userId: 'test-user',
         userEmail: 'user@test.com',
         token: 'test-token',

--- a/projects/lib/src/lib/services/luigi-config/navigation-global-context-config.service.ts
+++ b/projects/lib/src/lib/services/luigi-config/navigation-global-context-config.service.ts
@@ -21,6 +21,7 @@ export class NavigationGlobalContextConfigService {
     const envConfig = await this.envConfigService.getEnvConfig();
     return {
       ...(await this.luigiExtendedGlobalContextConfigService?.createLuigiExtendedGlobalContext()),
+      portalBaseUrl: window.location.origin,
       portalContext: portalConfig.portalContext,
       userId: userInfo.userId,
       userEmail: userInfo.email,

--- a/projects/lib/src/lib/services/luigi-nodes/node-context-processing.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/node-context-processing.service.spec.ts
@@ -90,6 +90,7 @@ describe('NodeContextProcessingService', () => {
       token: 'token123',
       organization: 'org-name',
       accountId: '1',
+      portalBaseUrl: 'https://example.com',
     };
 
     mockResourceService.read.mockReturnValue(of(entity));

--- a/projects/wc/src/app/components/organization-management/organization-management.component.spec.ts
+++ b/projects/wc/src/app/components/organization-management/organization-management.component.spec.ts
@@ -112,6 +112,7 @@ describe('OrganizationManagementComponent', () => {
       userEmail: 'user@test.com',
       token: 'token',
       organization: 'org1',
+      portalBaseUrl: 'https://test.com',
     };
     luigiCoreServiceMock.getGlobalContext.mockReturnValue(mockGlobalContext);
     resourceServiceMock.readOrganizations.mockReturnValue(

--- a/projects/wc/src/app/components/organization-management/organization-management.component.ts
+++ b/projects/wc/src/app/components/organization-management/organization-management.component.ts
@@ -105,7 +105,7 @@ export class OrganizationManagementComponent implements OnInit {
       metadata: { name: this.newOrganization },
     };
     const resourceDefinition: ResourceDefinition = {
-      group: 'core.openmfp.org',
+      group: 'core.platform-mesh.io',
       kind: 'Account',
       plural: 'accounts',
       singular: 'account',


### PR DESCRIPTION
- Add `portalBaseUrl` to Luigi context and update its usages in `navigation-global-context-config.service`.
- Replace organization management resource group to `core.platform-mesh.io` in relevant files.
- Update `@ui5/webcomponents-ngx` dependency versioning to use caret operator.