### PR TITLE
feat: adjust the local nodes processing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # Default code owners
-* @openmfp/frame
-* @openmfp/ui-approvers
+* @openmfp/frame @openmfp/ui-approvers
 package.json
 package-lock.json

--- a/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
@@ -168,11 +168,11 @@ export class LocalConfigurationServiceImpl {
   ) {
     const serverEntityTypes = [
       ...new Set(serverLuigiNodes.map((n) => n.entityType)),
-    ].join(',');
+    ].filter(Boolean).join(',');
 
     const localEntityTypes = [
       ...new Set(localNodes.map((n) => n.entityType)),
-    ].join(',');
+    ].filter(Boolean).join(',');
     console.debug(
       `Found '${serverLuigiNodes.length}' server nodes. 
        Found '${localNodes.length}' local luigi nodes. 

--- a/projects/lib/src/lib/services/luigi-nodes/luigi-nodes.service.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/luigi-nodes.service.ts
@@ -47,26 +47,17 @@ export class LuigiNodesService {
     return childrenByEntity;
   }
 
-  public async replaceServerNodesWithLocalOnes(
-    serverLuigiNodes: LuigiNode[],
-    currentEntities: string[],
-  ): Promise<LuigiNode[]> {
-    return await this.localConfigurationService.replaceServerNodesWithLocalOnes(
-      serverLuigiNodes,
-      currentEntities,
-    );
-  }
-
   async retrieveChildrenByEntity(): Promise<Record<string, LuigiNode[]>> {
     try {
       const portalConfig = await this.configService.getPortalConfig();
       const serverLuigiNodes: LuigiNode[] = portalConfig.providers.flatMap(
         (p) => p.nodes,
       );
-      const luigiNodes = await this.replaceServerNodesWithLocalOnes(
-        serverLuigiNodes,
-        ['global', 'main', 'home'],
-      );
+      const luigiNodes =
+        await this.localConfigurationService.replaceServerNodesWithLocalOnes(
+          serverLuigiNodes,
+          ['global', 'main', 'home'],
+        );
       return this.getChildrenByEntity(luigiNodes);
     } catch (e) {
       console.warn('Could not retrieve nodes, error: ', e);
@@ -74,10 +65,8 @@ export class LuigiNodesService {
     }
   }
 
-  async retrieveAndMergeEntityChildren(
+  async retrieveEntityChildren(
     entityDefinition: EntityDefinition,
-    existingChildren: LuigiNode[],
-    parentEntityPath: string,
     additionalContext?: Record<string, string>,
   ): Promise<LuigiNode[]> {
     let errorCode = 0;
@@ -104,14 +93,7 @@ export class LuigiNodesService {
       );
     }
 
-    const serverLuigiNodes: LuigiNode[] = configsForEntity.providers.flatMap(
-      (p) => p.nodes,
-    );
-    const rawEntityNodes = await this.replaceServerNodesWithLocalOnes(
-      serverLuigiNodes,
-      [parentEntityPath],
-    );
-    return [...(existingChildren || []), ...(rawEntityNodes || [])];
+    return configsForEntity.providers.flatMap((p) => p.nodes);
   }
 
   private createErrorNodes(


### PR DESCRIPTION
- Refactored Luigi service to simplify server-local node replacement logic.
- Updated `CODEOWNERS` to combine approvers into a single line.
- Adjusted handling of `entityType` in `local-configuration.service` to filter invalid entries.