### PR TITLE
Fix: service provider config being overwritten instead of extended (DXPFRAME-2172)

### DIFF
--- a/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
+++ b/projects/lib/src/lib/services/luigi-nodes/local-configuration.service.ts
@@ -63,7 +63,10 @@ export class LocalConfigurationServiceImpl {
       (result.nodes || []).forEach((node) => {
         node.context = {
           ...node.context,
-          serviceProviderConfig: localDevelopmentSettings.serviceProviderConfig,
+          serviceProviderConfig: {
+            ...node.context?.serviceProviderConfig,
+            ...localDevelopmentSettings.serviceProviderConfig,
+          },
         };
       });
 


### PR DESCRIPTION
The  `serviceProviderConfig` was overwritten and not extended, causing problems with the local setup during development of micro front-ends.

### Jira Issues

* [DXPFRAME-2172](https://jira.tools.sap/browse/DXPFRAME-2172): Search-UI broken in local development