### PR TITLE
breaking-change: update texts for extensions that cannot be displayed

### DIFF
--- a/projects/lib/src/lib/i18n/de.xliff
+++ b/projects/lib/src/lib/i18n/de.xliff
@@ -307,19 +307,24 @@
     <!-- PLUGIN TEXT -->
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN">
       <segment>
-        <target>{extensionLabel} kann nicht angezeigt werden</target>
+        <target>Die Erweiterung '{extensionLabel}' kann nicht angezeigt werden</target>
       </segment>
     </unit>
-     <unit id="PLUGIN_PAGE_NEED_EXTENSION">
-        <segment>
-            <target>Installiere Portal Chrome Erweiterung, damit du dir alle UIs in Portal anschauen kannst.</target>
-        </segment>
-     </unit>
-     <unit id="PLUGIN_PAGE_NEED_EXTENSION_CHROME">
-        <segment>
-            <target>Benutze Google Chrome mit der Portal Chrome Erweiterung, damit du dir alle UIs in Portal anschauen kannst.<br/> Sie können es auch in einem neuen Tab öffnen.</target>
-        </segment>
-     </unit>
+    <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE">
+      <segment>
+        <target>Die Erweiterung '{extensionLabel}' ist veraltet und kann nicht angezeigt werden</target>
+      </segment>
+    </unit>
+    <unit id="PLUGIN_PAGE_NEED_EXTENSION_UPDATE">
+      <segment>
+        <target>Die aktuelle Version der Erweiterung ist '{currentVersion}', benötigt wird jedoch Version '{requiredVersion}'</target>
+      </segment>
+    </unit>
+    <unit id="PLUGIN_PAGE_OPEN_IN_NEW_TAB">
+      <segment>
+        <target>Bitte öffnen Sie den Inhalt in einem neuen Tab.</target>
+      </segment>
+    </unit>
       <unit id="VPN_NEEDED_PAGE_TITLE">
         <segment>
             <target>VPN ist erforderlich</target>

--- a/projects/lib/src/lib/i18n/en.xliff
+++ b/projects/lib/src/lib/i18n/en.xliff
@@ -307,27 +307,22 @@
     <!-- PLUGIN TEXT -->
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN">
       <segment>
-        <target>{extensionLabel} can't be shown</target>
+        <target>The extension '{extensionLabel}' can't be shown</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE">
       <segment>
-        <target>{extensionLabel} can't be shown, Please update your browser extension.</target>
-      </segment>
-    </unit>
-    <unit id="PLUGIN_PAGE_NEED_EXTENSION">
-      <segment>
-         <target>Once you install the Portal Chrome extension, you can view all extension UIs without leaving the Portal.</target>
+        <target>The extension '{extensionLabel}' is outdated and can't be shown</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_NEED_EXTENSION_UPDATE">
       <segment>
-        <target>Once you update the Portal browser extension, you can view all extension UIs without leaving the Portal. You are running version '{currentVersion}', you require version '{requiredVersion}' </target>
+        <target>The extensions current version is '{currentVersion}' but you require version '{requiredVersion}'</target>
       </segment>
     </unit>
-    <unit id="PLUGIN_PAGE_NEED_EXTENSION_CHROME">
+    <unit id="PLUGIN_PAGE_OPEN_IN_NEW_TAB">
       <segment>
-        <target>Use Google Chrome with the Portal Chrome extension, to view this content here. <br/> You can also open it in a new tab.</target>
+        <target>Please open the content in a new tab.</target>
       </segment>
     </unit>
       <unit id="VPN_NEEDED_PAGE_TITLE">


### PR DESCRIPTION
In this change:
* BREAKING: remove key PLUGIN_PAGE_NEED_EXTENSION
* chore: update texts for the related keys when extension cannot be displayed
* chore: added missing translation for PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated plugin error messages in German and English with clearer extension status information.
* Enhanced version requirement notifications to display current and required versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->