### PR TITLE
chore: update plugin extension i18n texts to clarify embedding behavior

### DIFF
--- a/projects/lib/src/lib/i18n/de.xliff
+++ b/projects/lib/src/lib/i18n/de.xliff
@@ -307,12 +307,12 @@
     <!-- PLUGIN TEXT -->
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN">
       <segment>
-        <target>Die Erweiterung '{extensionLabel}' kann nicht im Portal eingebettet werden</target>
+        <target>Die Erweiterung '{extensionLabel}' ist so konfiguriert, dass sie externen Inhalt anzeigt, der im Portal nicht angezeigt werden kann</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE">
       <segment>
-        <target>Die Erweiterung '{extensionLabel}' ist veraltet und kann nicht im Portal eingebettet werden</target>
+        <target>Die Erweiterung '{extensionLabel}' ist veraltet und so konfiguriert, dass sie externen Inhalt anzeigt, der im Portal nicht angezeigt werden kann</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_NEED_EXTENSION_UPDATE">

--- a/projects/lib/src/lib/i18n/de.xliff
+++ b/projects/lib/src/lib/i18n/de.xliff
@@ -307,12 +307,12 @@
     <!-- PLUGIN TEXT -->
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN">
       <segment>
-        <target>Die Erweiterung '{extensionLabel}' kann nicht angezeigt werden</target>
+        <target>Die Erweiterung '{extensionLabel}' kann nicht im Portal eingebettet werden</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE">
       <segment>
-        <target>Die Erweiterung '{extensionLabel}' ist veraltet und kann nicht angezeigt werden</target>
+        <target>Die Erweiterung '{extensionLabel}' ist veraltet und kann nicht im Portal eingebettet werden</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_NEED_EXTENSION_UPDATE">
@@ -322,7 +322,7 @@
     </unit>
     <unit id="PLUGIN_PAGE_OPEN_IN_NEW_TAB">
       <segment>
-        <target>Bitte öffnen Sie den Inhalt in einem neuen Tab.</target>
+        <target>Bitte öffnen Sie den Inhalt der Erweiterung in einem neuen Tab.</target>
       </segment>
     </unit>
       <unit id="VPN_NEEDED_PAGE_TITLE">

--- a/projects/lib/src/lib/i18n/en.xliff
+++ b/projects/lib/src/lib/i18n/en.xliff
@@ -307,12 +307,12 @@
     <!-- PLUGIN TEXT -->
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN">
       <segment>
-        <target>The extension '{extensionLabel}' can't be shown</target>
+        <target>The extension '{extensionLabel}' can't be embedded in the Portal</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE">
       <segment>
-        <target>The extension '{extensionLabel}' is outdated and can't be shown</target>
+        <target>The extension '{extensionLabel}' is outdated and can't be embedded in the Portal</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_NEED_EXTENSION_UPDATE">
@@ -322,7 +322,7 @@
     </unit>
     <unit id="PLUGIN_PAGE_OPEN_IN_NEW_TAB">
       <segment>
-        <target>Please open the content in a new tab.</target>
+        <target>Please open the extension's content in a new tab.</target>
       </segment>
     </unit>
       <unit id="VPN_NEEDED_PAGE_TITLE">

--- a/projects/lib/src/lib/i18n/en.xliff
+++ b/projects/lib/src/lib/i18n/en.xliff
@@ -307,12 +307,12 @@
     <!-- PLUGIN TEXT -->
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN">
       <segment>
-        <target>The extension '{extensionLabel}' can't be embedded in the Portal</target>
+        <target>The extension '{extensionLabel}' is configured to display external content that cannot be shown inside the Portal</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_CAN_NOT_BE_SHOWN_UPDATE">
       <segment>
-        <target>The extension '{extensionLabel}' is outdated and can't be embedded in the Portal</target>
+        <target>The extension '{extensionLabel}' is outdated and configured to display external content that cannot be shown inside the Portal</target>
       </segment>
     </unit>
     <unit id="PLUGIN_PAGE_NEED_EXTENSION_UPDATE">


### PR DESCRIPTION
## Summary

- Replaces misleading "can't be shown" wording for plugin/extension messages with "can't be embedded in the Portal", making it clear this is a display context limitation rather than an error
- Updates the new tab prompt to reference "the extension's content" explicitly (EN) / "den Inhalt der Erweiterung" (DE)
