### PR TITLE
fix: signal expiry and drop stale auth data when the session refresh fails

### DIFF
--- a/projects/lib/src/lib/services/auth/session-refresh.service.spec.ts
+++ b/projects/lib/src/lib/services/auth/session-refresh.service.spec.ts
@@ -91,7 +91,7 @@ describe('SessionRefreshService', () => {
       );
     });
 
-    it('should not successfully refresh the session', async () => {
+    it('should signal expiry and drop stale auth data when the refresh fails', async () => {
       //Arrange
       const globalCtx = {} as LuigiGlobalContext;
       globalContextConfigServiceMock.getGlobalContext.mockResolvedValue(
@@ -104,6 +104,10 @@ describe('SessionRefreshService', () => {
 
       // Assert
       expect(authService.refresh).toHaveBeenCalled();
+      expect(authService.authEvent).toHaveBeenCalledWith(
+        AuthEvent.AUTH_EXPIRED,
+      );
+      expect(luigiCoreService.removeAuthData).toHaveBeenCalledTimes(1);
       expect(authService.authEvent).not.toHaveBeenCalledWith(
         AuthEvent.AUTH_REFRESHED,
       );
@@ -128,6 +132,7 @@ describe('SessionRefreshService', () => {
       // Act & Assert
       await expect(service.refresh()).rejects.toThrow('Refresh failed');
       expect(authService.authEvent).not.toHaveBeenCalled();
+      expect(luigiCoreService.removeAuthData).not.toHaveBeenCalled();
       expect(luigiCoreService.setAuthData).not.toHaveBeenCalled();
       expect(luigiCoreService.setGlobalContext).not.toHaveBeenCalled();
     });

--- a/projects/lib/src/lib/services/auth/session-refresh.service.ts
+++ b/projects/lib/src/lib/services/auth/session-refresh.service.ts
@@ -16,6 +16,14 @@ export class SessionRefreshService {
     const isRefreshed = await this.authService.refresh();
 
     if (!isRefreshed) {
+      // An empty refresh response means the server could not renew the session
+      // (the SSO session hit its idle timeout or absolute lifetime). Keeping the
+      // stale auth data leaves every later request carrying a dead token, which
+      // surfaces as unexplained 401s until the user reloads by hand. Signal the
+      // expiry - the redirect target is stored by the AUTH_EXPIRED subscriber -
+      // and drop the auth data so the frame re-authenticates.
+      this.authService.authEvent(AuthEvent.AUTH_EXPIRED);
+      this.luigiCoreService.removeAuthData();
       return;
     }
 


### PR DESCRIPTION
## Problem

When the session can no longer be refreshed (SSO session ended, refresh token invalid), `/rest/auth/refresh` answers `201` with an **empty body** (portal-server-lib's `AuthController.refresh()` returns `undefined` after `handleAuthError`). On the client, `setAuthData(undefined)` keeps the old auth data and `SessionRefreshService.refresh()` returned silently:

```ts
const isRefreshed = await this.authService.refresh();
if (!isRefreshed) return;
```

No event is fired and no re-login is triggered, so the user keeps an expired token and every API call 401s until a manual reload. Verified live: healthy refresh = 201 + full token JSON; after the Keycloak session is deleted = 201 + 0 bytes, silently swallowed.

## Change

On a failed refresh, fire the existing `AuthEvent.AUTH_EXPIRED` and remove the auth data via `LuigiCoreService.removeAuthData()`, so the already-existing expiry handling (redirect to login with the return URL saved) takes over.

## Tests

The previous spec *"should not successfully refresh the session"* asserted that nothing happens on a failed refresh — it codified the bug. It is replaced by *"should signal expiry and drop stale auth data when the refresh fails"*, which fails on the unpatched code. Full suite green (392 lib + 70 wc).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when session refresh fails by notifying the application that the session has expired.
  * Cleared stored authentication data after an unsuccessful refresh.
  * Preserved authentication data when refresh attempts fail due to an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->