### PR TITLE
Add default error screens (not-found, not-authorized, unexpected)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "tslib": "^2.8.1"
       },
       "devDependencies": {
+        "@analogjs/vitest-angular": "^2.7.0",
         "@angular-devkit/build-angular": "21.2.15",
         "@angular-eslint/builder": "^21.2.0",
         "@angular-eslint/eslint-plugin": "^21.2.0",
@@ -39,6 +40,7 @@
         "@vitest/coverage-v8": "4.1.10",
         "cpx2": "9.0.0",
         "eslint": "9.39.5",
+        "happy-dom": "^20.11.2",
         "jsdom": "30.0.1",
         "kubernetes-types": "1.30.0",
         "mkdirp": "3.0.1",
@@ -296,6 +298,63 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@analogjs/vite-plugin-angular": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@analogjs/vite-plugin-angular/-/vite-plugin-angular-2.7.0.tgz",
+      "integrity": "sha512-KhFC9wiIxD4vi0p3Iyd6tPXyvV9J8GF1eLTkANtBcUbuLkdCRFtbqp/U08cDt+Ae+mVOiSZliBO+JSr66YCqFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "oxc-parser": "^0.121.0",
+        "tinyglobby": "^0.2.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/brandonroberts"
+      },
+      "peerDependencies": {
+        "@angular-devkit/build-angular": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "@angular/build": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular-devkit/build-angular": {
+          "optional": true
+        },
+        "@angular/build": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@analogjs/vitest-angular": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@analogjs/vitest-angular/-/vitest-angular-2.7.0.tgz",
+      "integrity": "sha512-39qs+o5zGJ0xtzubNpy89t2/kwnYTl03US/z7YD1vss2Tb//R38ymjaLrUtirDW/X9nk5NdFGi8nasbctSDOrw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/brandonroberts"
+      },
+      "peerDependencies": {
+        "@analogjs/vite-plugin-angular": "*",
+        "@angular-devkit/architect": ">=0.1700.0 < 0.2300.0 || >=0.2200.0 < 0.2300.0",
+        "@angular-devkit/schematics": ">=17.0.0",
+        "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0",
+        "zone.js": ">=0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "zone.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/architect": {
@@ -5828,6 +5887,390 @@
         "typescript-eslint": "^8.24.0"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.113.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.113.0.tgz",
@@ -7748,6 +8191,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -9550,6 +10000,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -11975,6 +12438,48 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.2.tgz",
+      "integrity": "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -14992,6 +15497,56 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "^0.121.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
+    "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
+    "@analogjs/vitest-angular": "^2.7.0",
     "@angular-devkit/build-angular": "21.2.15",
     "@angular-eslint/builder": "^21.2.0",
     "@angular-eslint/eslint-plugin": "^21.2.0",
@@ -78,6 +79,7 @@
     "@vitest/coverage-v8": "4.1.10",
     "cpx2": "9.0.0",
     "eslint": "9.39.5",
+    "happy-dom": "^20.11.2",
     "jsdom": "30.0.1",
     "kubernetes-types": "1.30.0",
     "mkdirp": "3.0.1",

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.html
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.html
@@ -11,14 +11,19 @@
         <div class="info" data-e2e="error-title">{{ title() }}</div>
         <div class="hint" data-e2e="error-subtitle">{{ subtitle() }}</div>
 
-        @if (code()) {
+        @if (code() || message()) {
           <details
             class="error-details"
             [attr.open]="expandedByDefault() ? '' : null"
             data-e2e="error-details"
           >
             <summary data-e2e="error-details-toggle">{{ errorDetailsLabel() }}</summary>
-            <span data-e2e="error-code">{{ code() }}</span>
+            @if (code()) {
+              <span data-e2e="error-code">{{ code() }}</span>
+            }
+            @if (message()) {
+              <span data-e2e="error-message">{{ message() }}</span>
+            }
           </details>
         }
 

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.html
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.html
@@ -11,6 +11,17 @@
         <div class="info" data-e2e="error-title">{{ title() }}</div>
         <div class="hint" data-e2e="error-subtitle">{{ subtitle() }}</div>
 
+        @if (code()) {
+          <details
+            class="error-details"
+            [attr.open]="expandedByDefault() ? '' : null"
+            data-e2e="error-details"
+          >
+            <summary data-e2e="error-details-toggle">{{ errorDetailsLabel() }}</summary>
+            <span data-e2e="error-code">{{ code() }}</span>
+          </details>
+        }
+
         <p class="fd-has-text-align-center">
           <button
             class="fd-button fd-button--action-bar fd-button--l"

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.html
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.html
@@ -1,0 +1,26 @@
+<div class="fd-page">
+  <link rel="stylesheet" href="/fundamental-styles/fundamental-styles.css" />
+  <div class="fd-page__content">
+    <div class="fd-container fd-container--centered">
+      <div class="content">
+        <span
+          [class]="'error-screen-icon ' + icon()"
+          data-e2e="error-icon"
+        ></span>
+
+        <div class="info" data-e2e="error-title">{{ title() }}</div>
+        <div class="hint" data-e2e="error-subtitle">{{ subtitle() }}</div>
+
+        <p class="fd-has-text-align-center">
+          <button
+            class="fd-button fd-button--action-bar fd-button--l"
+            (click)="goHome()"
+            data-e2e="error-go-home-button"
+          >
+            {{ buttonText() }}
+          </button>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.scss
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.scss
@@ -1,0 +1,101 @@
+
+@font-face {
+  font-family: '72';
+  src: url('/fundamental-styles/72-Light-full.woff')
+  format('woff');
+  font-weight: 300;
+  font-style: normal;
+}
+@font-face {
+  font-family: '72';
+  src: url('/fundamental-styles/72-Light-full.woff2')
+  format('woff2');
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: '72';
+  src: url('/fundamental-styles/72-Bold-full.woff')
+  format('woff');
+  font-weight: 700;
+  font-style: normal;
+}
+@font-face {
+  font-family: '72';
+  src: url('/fundamental-styles/72-Bold-full.woff2')
+  format('woff2');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: '72';
+  src: url('/fundamental-styles/72-Regular-full.woff')
+  format('woff');
+  font-weight: 400;
+  font-style: normal;
+}
+@font-face {
+  font-family: '72';
+  src: url('/fundamental-styles/72-Regular-full.woff2')
+  format('woff2');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'SAP-icons';
+  src: url('/fundamental-styles/SAP-icons.woff')
+  format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: 'SAP-icons';
+  src: url('/fundamental-styles/SAP-icons.woff2')
+  format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+
+body {
+  margin: 0;
+}
+
+.error-screen-icon::before {
+  font-size: 150px;
+  color: #a0a0a0;
+}
+.fd-container--centered {
+  text-align: center;
+}
+a.fd-button {
+  color: #FFF;
+}
+.fd-page {
+  margin-top: 32px;
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.content {
+  width: 100%;
+}
+.fd-has-text-align-center {
+  text-align: center;
+}
+.info, .hint {
+  text-align: center;
+  margin: 0;
+}
+.info {
+  padding-top: 30px;
+  font-size: 36px;
+}
+.hint {
+  font-size: 18px;
+  color: #6f7275;
+  padding-bottom: 30px;
+}

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.scss
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.scss
@@ -99,3 +99,36 @@ a.fd-button {
   color: #6f7275;
   padding-bottom: 30px;
 }
+
+.error-details {
+  text-align: center;
+  margin: 0 auto 20px;
+  color: #6f7275;
+  font-size: 14px;
+  cursor: pointer;
+
+  summary {
+    list-style: none;
+    padding: 6px 12px;
+    display: inline-block;
+
+    &::marker,
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::before {
+      content: '▶\00a0';
+    }
+  }
+
+  &[open] summary::before {
+    content: '▼\00a0';
+  }
+
+  span {
+    display: block;
+    margin-top: 6px;
+    font-family: monospace;
+  }
+}

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.spec.ts
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.spec.ts
@@ -7,21 +7,27 @@ const NOT_FOUND_DATA = {
   icon: 'sap-icon--search',
   titleKey: 'ERROR_NOT_FOUND_TITLE',
   subtitleKey: 'ERROR_NOT_FOUND_SUBTITLE',
+  expandedByDefault: false,
 };
 const NOT_AUTHORIZED_DATA = {
   icon: 'sap-icon--locked',
   titleKey: 'ERROR_NOT_AUTHORIZED_TITLE',
   subtitleKey: 'ERROR_NOT_AUTHORIZED_SUBTITLE',
+  expandedByDefault: false,
 };
 const UNEXPECTED_DATA = {
   icon: 'sap-icon--alert',
   titleKey: 'ERROR_UNEXPECTED_TITLE',
   subtitleKey: 'ERROR_UNEXPECTED_SUBTITLE',
+  expandedByDefault: true,
 };
 
-function buildTestBed(routeData: Record<string, string>) {
+function buildTestBed(
+  routeData: Record<string, unknown>,
+  queryParams: Record<string, string> = {},
+) {
   const mockRoute: ActivatedRoute = {
-    snapshot: { data: routeData, queryParams: {} },
+    snapshot: { data: routeData, queryParams },
   } as any;
   const mockRouter = { navigate: vi.fn() };
   const mockLuigiCoreService = {
@@ -77,6 +83,16 @@ describe('ErrorScreenComponent', () => {
       expect(component.icon()).toBe('sap-icon--search');
     });
 
+    it('should set expandedByDefault to false', async () => {
+      await component.ngOnInit();
+      expect(component.expandedByDefault()).toBe(false);
+    });
+
+    it('should set empty code when no query param provided', async () => {
+      await component.ngOnInit();
+      expect(component.code()).toBe('');
+    });
+
     it('should request correct i18n keys for not-found', async () => {
       await component.ngOnInit();
       expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
@@ -88,13 +104,17 @@ describe('ErrorScreenComponent', () => {
       expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
         'ERROR_GO_HOME_BUTTON',
       );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_DETAILS_LABEL',
+      );
     });
 
-    it('should set title, subtitle, buttonText from translations', async () => {
+    it('should set title, subtitle, buttonText, errorDetailsLabel from translations', async () => {
       await component.ngOnInit();
       expect(component.title()).toBe('ERROR_NOT_FOUND_TITLE_translated');
       expect(component.subtitle()).toBe('ERROR_NOT_FOUND_SUBTITLE_translated');
       expect(component.buttonText()).toBe('ERROR_GO_HOME_BUTTON_translated');
+      expect(component.errorDetailsLabel()).toBe('ERROR_DETAILS_LABEL_translated');
     });
 
     it('should navigate to / when goHome() is called', () => {
@@ -129,6 +149,11 @@ describe('ErrorScreenComponent', () => {
     it('should set icon from route data', async () => {
       await component.ngOnInit();
       expect(component.icon()).toBe('sap-icon--locked');
+    });
+
+    it('should set expandedByDefault to false', async () => {
+      await component.ngOnInit();
+      expect(component.expandedByDefault()).toBe(false);
     });
 
     it('should request correct i18n keys for not-authorized', async () => {
@@ -187,6 +212,11 @@ describe('ErrorScreenComponent', () => {
       expect(component.icon()).toBe('sap-icon--alert');
     });
 
+    it('should set expandedByDefault to true', async () => {
+      await component.ngOnInit();
+      expect(component.expandedByDefault()).toBe(true);
+    });
+
     it('should request correct i18n keys for unexpected-error', async () => {
       await component.ngOnInit();
       expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
@@ -213,6 +243,44 @@ describe('ErrorScreenComponent', () => {
     });
   });
 
+  describe('error code via query param', () => {
+    it('should display code when ?code= query param is provided', async () => {
+      buildTestBed(UNEXPECTED_DATA, { code: '500' });
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await component.ngOnInit();
+
+      expect(component.code()).toBe('500');
+    });
+
+    it('should display string error code', async () => {
+      buildTestBed(NOT_FOUND_DATA, { code: 'ERR_NOT_FOUND' });
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await component.ngOnInit();
+
+      expect(component.code()).toBe('ERR_NOT_FOUND');
+    });
+
+    it('should have empty code when no query param provided', async () => {
+      buildTestBed(UNEXPECTED_DATA);
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await component.ngOnInit();
+
+      expect(component.code()).toBe('');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle missing route data gracefully', async () => {
       buildTestBed({});
@@ -224,6 +292,8 @@ describe('ErrorScreenComponent', () => {
       await component.ngOnInit();
 
       expect(component.icon()).toBe('');
+      expect(component.expandedByDefault()).toBe(false);
+      expect(component.code()).toBe('');
     });
   });
 });

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.spec.ts
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.spec.ts
@@ -268,7 +268,32 @@ describe('ErrorScreenComponent', () => {
       expect(component.code()).toBe('ERR_NOT_FOUND');
     });
 
-    it('should have empty code when no query param provided', async () => {
+    it('should display message when ?message= query param is provided', async () => {
+      buildTestBed(UNEXPECTED_DATA, { message: 'Database connection failed' });
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await component.ngOnInit();
+
+      expect(component.message()).toBe('Database connection failed');
+    });
+
+    it('should display both code and message when both params are provided', async () => {
+      buildTestBed(UNEXPECTED_DATA, { code: '500', message: 'Internal Server Error' });
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await component.ngOnInit();
+
+      expect(component.code()).toBe('500');
+      expect(component.message()).toBe('Internal Server Error');
+    });
+
+    it('should have empty code and message when no query params provided', async () => {
       buildTestBed(UNEXPECTED_DATA);
       await TestBed.compileComponents();
       fixture = TestBed.createComponent(ErrorScreenComponent);
@@ -278,6 +303,7 @@ describe('ErrorScreenComponent', () => {
       await component.ngOnInit();
 
       expect(component.code()).toBe('');
+      expect(component.message()).toBe('');
     });
   });
 

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.spec.ts
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.spec.ts
@@ -1,0 +1,229 @@
+import { I18nService, LuigiCoreService } from '../../services';
+import { ErrorScreenComponent } from './error-screen.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+
+const NOT_FOUND_DATA = {
+  icon: 'sap-icon--search',
+  titleKey: 'ERROR_NOT_FOUND_TITLE',
+  subtitleKey: 'ERROR_NOT_FOUND_SUBTITLE',
+};
+const NOT_AUTHORIZED_DATA = {
+  icon: 'sap-icon--locked',
+  titleKey: 'ERROR_NOT_AUTHORIZED_TITLE',
+  subtitleKey: 'ERROR_NOT_AUTHORIZED_SUBTITLE',
+};
+const UNEXPECTED_DATA = {
+  icon: 'sap-icon--alert',
+  titleKey: 'ERROR_UNEXPECTED_TITLE',
+  subtitleKey: 'ERROR_UNEXPECTED_SUBTITLE',
+};
+
+function buildTestBed(routeData: Record<string, string>) {
+  const mockRoute: ActivatedRoute = {
+    snapshot: { data: routeData, queryParams: {} },
+  } as any;
+  const mockRouter = { navigate: vi.fn() };
+  const mockLuigiCoreService = {
+    ux: vi.fn(() => ({ hideAppLoadingIndicator: vi.fn() })),
+  };
+  const mockI18nService = {
+    getTranslationAsync: vi
+      .fn()
+      .mockImplementation((key: string) => Promise.resolve(key + '_translated')),
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: ActivatedRoute, useValue: mockRoute },
+      { provide: Router, useValue: mockRouter },
+      { provide: LuigiCoreService, useValue: mockLuigiCoreService },
+      { provide: I18nService, useValue: mockI18nService },
+    ],
+  });
+
+  return { mockRoute, mockRouter, mockLuigiCoreService, mockI18nService };
+}
+
+describe('ErrorScreenComponent', () => {
+  let component: ErrorScreenComponent;
+  let fixture: ComponentFixture<ErrorScreenComponent>;
+
+  describe('not-found configuration', () => {
+    let mockLuigiCoreService: { ux: ReturnType<typeof vi.fn> };
+    let mockRouter: { navigate: ReturnType<typeof vi.fn> };
+    let mockI18nService: { getTranslationAsync: ReturnType<typeof vi.fn> };
+
+    beforeEach(async () => {
+      ({ mockLuigiCoreService, mockRouter, mockI18nService } = buildTestBed(
+        NOT_FOUND_DATA,
+      ));
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should call hideAppLoadingIndicator on init', () => {
+      expect(mockLuigiCoreService.ux).toHaveBeenCalled();
+    });
+
+    it('should set icon from route data', async () => {
+      await component.ngOnInit();
+      expect(component.icon()).toBe('sap-icon--search');
+    });
+
+    it('should request correct i18n keys for not-found', async () => {
+      await component.ngOnInit();
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_NOT_FOUND_TITLE',
+      );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_NOT_FOUND_SUBTITLE',
+      );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_GO_HOME_BUTTON',
+      );
+    });
+
+    it('should set title, subtitle, buttonText from translations', async () => {
+      await component.ngOnInit();
+      expect(component.title()).toBe('ERROR_NOT_FOUND_TITLE_translated');
+      expect(component.subtitle()).toBe('ERROR_NOT_FOUND_SUBTITLE_translated');
+      expect(component.buttonText()).toBe('ERROR_GO_HOME_BUTTON_translated');
+    });
+
+    it('should navigate to / when goHome() is called', () => {
+      component.goHome();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+    });
+  });
+
+  describe('not-authorized configuration', () => {
+    let mockLuigiCoreService: { ux: ReturnType<typeof vi.fn> };
+    let mockRouter: { navigate: ReturnType<typeof vi.fn> };
+    let mockI18nService: { getTranslationAsync: ReturnType<typeof vi.fn> };
+
+    beforeEach(async () => {
+      ({ mockLuigiCoreService, mockRouter, mockI18nService } = buildTestBed(
+        NOT_AUTHORIZED_DATA,
+      ));
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should call hideAppLoadingIndicator on init', () => {
+      expect(mockLuigiCoreService.ux).toHaveBeenCalled();
+    });
+
+    it('should set icon from route data', async () => {
+      await component.ngOnInit();
+      expect(component.icon()).toBe('sap-icon--locked');
+    });
+
+    it('should request correct i18n keys for not-authorized', async () => {
+      await component.ngOnInit();
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_NOT_AUTHORIZED_TITLE',
+      );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_NOT_AUTHORIZED_SUBTITLE',
+      );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_GO_HOME_BUTTON',
+      );
+    });
+
+    it('should set title, subtitle, buttonText from translations', async () => {
+      await component.ngOnInit();
+      expect(component.title()).toBe('ERROR_NOT_AUTHORIZED_TITLE_translated');
+      expect(component.subtitle()).toBe(
+        'ERROR_NOT_AUTHORIZED_SUBTITLE_translated',
+      );
+      expect(component.buttonText()).toBe('ERROR_GO_HOME_BUTTON_translated');
+    });
+
+    it('should navigate to / when goHome() is called', () => {
+      component.goHome();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+    });
+  });
+
+  describe('unexpected-error configuration', () => {
+    let mockLuigiCoreService: { ux: ReturnType<typeof vi.fn> };
+    let mockRouter: { navigate: ReturnType<typeof vi.fn> };
+    let mockI18nService: { getTranslationAsync: ReturnType<typeof vi.fn> };
+
+    beforeEach(async () => {
+      ({ mockLuigiCoreService, mockRouter, mockI18nService } = buildTestBed(
+        UNEXPECTED_DATA,
+      ));
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should call hideAppLoadingIndicator on init', () => {
+      expect(mockLuigiCoreService.ux).toHaveBeenCalled();
+    });
+
+    it('should set icon from route data', async () => {
+      await component.ngOnInit();
+      expect(component.icon()).toBe('sap-icon--alert');
+    });
+
+    it('should request correct i18n keys for unexpected-error', async () => {
+      await component.ngOnInit();
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_UNEXPECTED_TITLE',
+      );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_UNEXPECTED_SUBTITLE',
+      );
+      expect(mockI18nService.getTranslationAsync).toHaveBeenCalledWith(
+        'ERROR_GO_HOME_BUTTON',
+      );
+    });
+
+    it('should set title, subtitle, buttonText from translations', async () => {
+      await component.ngOnInit();
+      expect(component.title()).toBe('ERROR_UNEXPECTED_TITLE_translated');
+      expect(component.subtitle()).toBe('ERROR_UNEXPECTED_SUBTITLE_translated');
+      expect(component.buttonText()).toBe('ERROR_GO_HOME_BUTTON_translated');
+    });
+
+    it('should navigate to / when goHome() is called', () => {
+      component.goHome();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle missing route data gracefully', async () => {
+      buildTestBed({});
+      await TestBed.compileComponents();
+      fixture = TestBed.createComponent(ErrorScreenComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      await component.ngOnInit();
+
+      expect(component.icon()).toBe('');
+    });
+  });
+});

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.ts
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.ts
@@ -1,0 +1,46 @@
+import { I18nService, LuigiCoreService } from '../../services';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  templateUrl: './error-screen.component.html',
+  styleUrls: ['./error-screen.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ErrorScreenComponent implements OnInit {
+  title = signal<string>('');
+  subtitle = signal<string>('');
+  buttonText = signal<string>('');
+  icon = signal<string>('');
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private luigiCoreService: LuigiCoreService,
+    private i18nService: I18nService,
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+    this.luigiCoreService.ux().hideAppLoadingIndicator();
+    const data = this.route.snapshot.data;
+    this.icon.set(data['icon'] ?? '');
+    const [title, subtitle, buttonText] = await Promise.all([
+      this.i18nService.getTranslationAsync(data['titleKey']),
+      this.i18nService.getTranslationAsync(data['subtitleKey']),
+      this.i18nService.getTranslationAsync('ERROR_GO_HOME_BUTTON'),
+    ]);
+    this.title.set(title);
+    this.subtitle.set(subtitle);
+    this.buttonText.set(buttonText);
+  }
+
+  goHome(): void {
+    this.router.navigate(['/']);
+  }
+}

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.ts
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.ts
@@ -19,6 +19,7 @@ export class ErrorScreenComponent implements OnInit {
   buttonText = signal<string>('');
   icon = signal<string>('');
   code = signal<string>('');
+  message = signal<string>('');
   expandedByDefault = signal<boolean>(false);
   errorDetailsLabel = signal<string>('');
 
@@ -35,6 +36,7 @@ export class ErrorScreenComponent implements OnInit {
     this.icon.set(data['icon'] ?? '');
     this.expandedByDefault.set(data['expandedByDefault'] ?? false);
     this.code.set(this.route.snapshot.queryParams['code'] ?? '');
+    this.message.set(this.route.snapshot.queryParams['message'] ?? '');
     const [title, subtitle, buttonText, errorDetailsLabel] = await Promise.all([
       this.i18nService.getTranslationAsync(data['titleKey']),
       this.i18nService.getTranslationAsync(data['subtitleKey']),

--- a/projects/lib/src/lib/components/error-screen/error-screen.component.ts
+++ b/projects/lib/src/lib/components/error-screen/error-screen.component.ts
@@ -18,6 +18,9 @@ export class ErrorScreenComponent implements OnInit {
   subtitle = signal<string>('');
   buttonText = signal<string>('');
   icon = signal<string>('');
+  code = signal<string>('');
+  expandedByDefault = signal<boolean>(false);
+  errorDetailsLabel = signal<string>('');
 
   constructor(
     private route: ActivatedRoute,
@@ -30,14 +33,18 @@ export class ErrorScreenComponent implements OnInit {
     this.luigiCoreService.ux().hideAppLoadingIndicator();
     const data = this.route.snapshot.data;
     this.icon.set(data['icon'] ?? '');
-    const [title, subtitle, buttonText] = await Promise.all([
+    this.expandedByDefault.set(data['expandedByDefault'] ?? false);
+    this.code.set(this.route.snapshot.queryParams['code'] ?? '');
+    const [title, subtitle, buttonText, errorDetailsLabel] = await Promise.all([
       this.i18nService.getTranslationAsync(data['titleKey']),
       this.i18nService.getTranslationAsync(data['subtitleKey']),
       this.i18nService.getTranslationAsync('ERROR_GO_HOME_BUTTON'),
+      this.i18nService.getTranslationAsync('ERROR_DETAILS_LABEL'),
     ]);
     this.title.set(title);
     this.subtitle.set(subtitle);
     this.buttonText.set(buttonText);
+    this.errorDetailsLabel.set(errorDetailsLabel);
   }
 
   goHome(): void {

--- a/projects/lib/src/lib/components/index.ts
+++ b/projects/lib/src/lib/components/index.ts
@@ -1,3 +1,4 @@
+export { ErrorScreenComponent } from './error-screen/error-screen.component';
 export { LogoutComponent } from './logout/logout.component';
 export { LuigiComponent } from './luigi/luigi.component';
 export { PortalComponent } from './portal/portal.component';

--- a/projects/lib/src/lib/i18n/de.xliff
+++ b/projects/lib/src/lib/i18n/de.xliff
@@ -501,5 +501,41 @@
         <target>Feature Toggle ist über Query-Parameter aktiviert</target>
       </segment>
     </unit>
+    <!--ERROR SCREENS-->
+    <unit id="ERROR_NOT_FOUND_TITLE">
+      <segment>
+        <target>Seite nicht gefunden</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_NOT_FOUND_SUBTITLE">
+      <segment>
+        <target>Die gesuchte Seite existiert nicht.</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_NOT_AUTHORIZED_TITLE">
+      <segment>
+        <target>Zugriff verweigert</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_NOT_AUTHORIZED_SUBTITLE">
+      <segment>
+        <target>Sie haben keine Berechtigung, auf diese Seite zuzugreifen.</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_UNEXPECTED_TITLE">
+      <segment>
+        <target>Unerwarteter Fehler</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_UNEXPECTED_SUBTITLE">
+      <segment>
+        <target>Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_GO_HOME_BUTTON">
+      <segment>
+        <target>Zur Startseite</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/projects/lib/src/lib/i18n/de.xliff
+++ b/projects/lib/src/lib/i18n/de.xliff
@@ -537,5 +537,10 @@
         <target>Zur Startseite</target>
       </segment>
     </unit>
+    <unit id="ERROR_DETAILS_LABEL">
+      <segment>
+        <target>Fehlerdetails</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/projects/lib/src/lib/i18n/en.xliff
+++ b/projects/lib/src/lib/i18n/en.xliff
@@ -541,5 +541,10 @@
         <target>Go Home</target>
       </segment>
     </unit>
+    <unit id="ERROR_DETAILS_LABEL">
+      <segment>
+        <target>Error details</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/projects/lib/src/lib/i18n/en.xliff
+++ b/projects/lib/src/lib/i18n/en.xliff
@@ -505,5 +505,41 @@
         <target>Feature toggle is enabled by query parameter</target>
        </segment>
      </unit>
+    <!--ERROR SCREENS-->
+    <unit id="ERROR_NOT_FOUND_TITLE">
+      <segment>
+        <target>Page Not Found</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_NOT_FOUND_SUBTITLE">
+      <segment>
+        <target>The page you are looking for does not exist.</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_NOT_AUTHORIZED_TITLE">
+      <segment>
+        <target>Access Denied</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_NOT_AUTHORIZED_SUBTITLE">
+      <segment>
+        <target>You do not have permission to access this page.</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_UNEXPECTED_TITLE">
+      <segment>
+        <target>Unexpected Error</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_UNEXPECTED_SUBTITLE">
+      <segment>
+        <target>An unexpected error occurred. Please try again later.</target>
+      </segment>
+    </unit>
+    <unit id="ERROR_GO_HOME_BUTTON">
+      <segment>
+        <target>Go Home</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/projects/lib/src/lib/portal-routing.ts
+++ b/projects/lib/src/lib/portal-routing.ts
@@ -1,8 +1,35 @@
-import { LogoutComponent, LuigiComponent } from './components';
+import { ErrorScreenComponent, LogoutComponent, LuigiComponent } from './components';
 import { Routes } from '@angular/router';
 
 export const portalRouts: Routes = [
   { path: 'logout', component: LogoutComponent },
+  {
+    path: 'error/not-found',
+    component: ErrorScreenComponent,
+    data: {
+      icon: 'sap-icon--search',
+      titleKey: 'ERROR_NOT_FOUND_TITLE',
+      subtitleKey: 'ERROR_NOT_FOUND_SUBTITLE',
+    },
+  },
+  {
+    path: 'error/not-authorized',
+    component: ErrorScreenComponent,
+    data: {
+      icon: 'sap-icon--locked',
+      titleKey: 'ERROR_NOT_AUTHORIZED_TITLE',
+      subtitleKey: 'ERROR_NOT_AUTHORIZED_SUBTITLE',
+    },
+  },
+  {
+    path: 'error/unexpected',
+    component: ErrorScreenComponent,
+    data: {
+      icon: 'sap-icon--alert',
+      titleKey: 'ERROR_UNEXPECTED_TITLE',
+      subtitleKey: 'ERROR_UNEXPECTED_SUBTITLE',
+    },
+  },
   { path: '', component: LuigiComponent },
   { path: '**', component: LuigiComponent },
 ];

--- a/projects/lib/src/lib/portal-routing.ts
+++ b/projects/lib/src/lib/portal-routing.ts
@@ -28,6 +28,7 @@ export const portalRouts: Routes = [
       icon: 'sap-icon--alert',
       titleKey: 'ERROR_UNEXPECTED_TITLE',
       subtitleKey: 'ERROR_UNEXPECTED_SUBTITLE',
+      expandedByDefault: true,
     },
   },
   { path: '', component: LuigiComponent },

--- a/projects/lib/src/lib/services/luigi-config/global-context-config.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-config/global-context-config.service.spec.ts
@@ -37,9 +37,6 @@ describe('GlobalContextConfigService', () => {
     });
 
     globalContextConfigService = TestBed.inject(GlobalContextConfigService);
-
-    delete (window as any).location;
-    window.location = { origin: 'https://example.com' } as any;
   });
 
   it('should be created', () => {

--- a/projects/lib/src/lib/services/luigi-config/user-settings-config.service.spec.ts
+++ b/projects/lib/src/lib/services/luigi-config/user-settings-config.service.spec.ts
@@ -36,12 +36,7 @@ describe('UserSettingsConfigService', () => {
       uiOptions: ['enableFeatureToggleSetting'],
     } as ClientEnvironment);
 
-    const originalLocation = window.location;
-    delete (window as any).location;
-    window.location = {
-      ...originalLocation,
-      reload: vi.fn(),
-    } as any;
+    vi.spyOn(window.location, 'reload').mockImplementation(() => {});
 
     dependenciesVersionsService.read.mockResolvedValue({});
     luigiCoreServiceMock.getActiveFeatureToggleList.mockReturnValue([]);

--- a/projects/lib/src/lib/services/portal/config.service.spec.ts
+++ b/projects/lib/src/lib/services/portal/config.service.spec.ts
@@ -64,33 +64,18 @@ describe('ConfigService', () => {
     });
 
     it('should handle 403 error', async () => {
-      const mockLocation = {
-        assign: vi.fn(),
-        href: '',
-        pathname: '',
-        search: '',
-        hash: '',
-        host: '',
-        hostname: '',
-        port: '',
-        protocol: '',
-        origin: '',
-        reload: vi.fn(),
-        replace: vi.fn(),
-        toString: vi.fn(),
-      } as any;
-
-      delete (window as any).location;
-      window.location = mockLocation;
+      const assignSpy = vi
+        .spyOn(window.location, 'assign')
+        .mockImplementation(() => {});
 
       const configPromise = service.getPortalConfig();
       const testRequest = httpTestingController.expectOne('/rest/config');
       testRequest.flush({}, { status: 403, statusText: 'Forbidden' });
 
       await expect(configPromise).rejects.toBeTruthy();
-      expect(window.location.assign).toHaveBeenCalledWith(
-        '/logout?error=invalidToken',
-      );
+      expect(assignSpy).toHaveBeenCalledWith('/logout?error=invalidToken');
+
+      assignSpy.mockRestore();
     });
 
     it('should get the luigi nodes only once', async () => {

--- a/projects/lib/src/lib/utilities/preserve-query-params-url-handling.strategy.spec.ts
+++ b/projects/lib/src/lib/utilities/preserve-query-params-url-handling.strategy.spec.ts
@@ -1,6 +1,6 @@
 import { PreserveQueryParamsUrlHandlingStrategy } from './preserve-query-params-url-handling.strategy';
 import { UrlTree } from '@angular/router';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 describe('PreserveQueryParamsUrlHandlingStrategy', () => {
   let strategy: PreserveQueryParamsUrlHandlingStrategy;
@@ -30,12 +30,12 @@ describe('PreserveQueryParamsUrlHandlingStrategy', () => {
 
   describe('merge', () => {
     const setLocationSearch = (search: string) => {
-      Object.defineProperty(window, 'location', {
-        value: { ...window.location, search, href: `http://x${search}` },
-        writable: true,
-        configurable: true,
-      });
+      window.history.pushState({}, '', search || '/');
     };
+
+    afterEach(() => {
+      window.history.pushState({}, '', '/');
+    });
 
     it('injects the live location.search params when the router built none', () => {
       setLocationSearch('?q=foo&page=2&owner=me');

--- a/projects/lib/src/public-api.ts
+++ b/projects/lib/src/public-api.ts
@@ -5,6 +5,7 @@
 export * from './lib/portal-providers';
 export * from './lib/injection-tokens';
 export * from './lib/components/portal/portal.component';
+export * from './lib/components/error-screen/error-screen.component';
 
 export * from './lib/models';
 export * from './lib/services';

--- a/projects/test-setup.ts
+++ b/projects/test-setup.ts
@@ -1,3 +1,7 @@
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed();
+
 function createMemoryStorage(): Storage {
   const store = new Map<string, string>();
   return {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,22 @@
 import { defineConfig } from 'vitest/config';
+import angular from '@analogjs/vite-plugin-angular';
+import { resolve } from 'path';
 
 export default defineConfig({
+  plugins: [angular()],
+  resolve: {
+    alias: {
+      '@openmfp/portal-ui-lib': resolve(__dirname, 'projects/lib/src/public-api.ts'),
+    },
+  },
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
+    environmentOptions: {
+      happyDOM: {
+        url: 'https://example.com',
+      },
+    },
     setupFiles: ['./projects/test-setup.ts'],
   },
 });


### PR DESCRIPTION
Closes #659

## Summary
Portals no longer need to implement their own error UIs. Three default
screens are now available out of the box via `providePortal()`:

- `/error/not-found`
- `/error/not-authorized`  
- `/error/unexpected`

Each shows a SAP icon, translated title/subtitle and a "Go Home" button.
EN + DE translations included.

Also fixes pre-existing Vitest infrastructure issues that prevented the
test suite from running (0 → 488 tests passing).

## Breaking changes
None — purely additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized error screens for not-found, unauthorized, and unexpected errors.
  * Added contextual icons, messages, expandable error details, and a button to return home.
  * Added English and German translations.
  * Exposed the error screen for use throughout the library.

* **Tests**
  * Expanded coverage for error-screen behavior, navigation, localization, and error-code handling.
  * Improved browser-environment test setup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->