### PR TITLE
fix: replace outdated jmespath with @jmespath-community/jmespath [DXPFRAME-2504]

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -16,6 +16,6 @@
     "@luigi-project/plugin-auth-oauth2",
     "lodash.isequal",
     "lodash.ismatch",
-    "jmespath"
+    "@jmespath-community/jmespath"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.194.21",
       "license": "Apache-2.0",
       "dependencies": {
+        "@jmespath-community/jmespath": "^1.3.0",
         "@luigi-project/plugin-auth-oauth2": "^2.27.0",
-        "jmespath": "^0.16.0",
         "jwt-decode": "^4.0.0",
         "lodash.isequal": "^4.5.0",
         "lodash.ismatch": "^4.4.0",
@@ -31,7 +31,6 @@
         "@fundamental-ngx/ui5-webcomponents": "0.63.0",
         "@openmfp/config-prettier": "0.9.2",
         "@openmfp/eslint-config-typescript": "0.7.11",
-        "@types/jmespath": "0.15.2",
         "@types/lodash": "4.17.25",
         "@types/node": "24.13.3",
         "@typescript-eslint/eslint-plugin": "8.66.0",
@@ -4395,6 +4394,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jmespath-community/jmespath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jmespath-community/jmespath/-/jmespath-1.3.0.tgz",
+      "integrity": "sha512-nzOrEdWKNpognj6CT+1Atr7gw0bqUC1KTBRyasBXS9NjFpz+og7LeFZrIQqV81GRcCzKa5H+DNipvv7NQK3GzA==",
+      "license": "MPL-2.0",
+      "bin": {
+        "jp": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -7574,13 +7585,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/jmespath": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@types/jmespath/-/jmespath-0.15.2.tgz",
-      "integrity": "sha512-pegh49FtNsC389Flyo9y8AfkVIZn9MMPE9yJrO9svhq6Fks2MwymULWjZqySuxmctd3ZH4/n7Mr98D+1Qo5vGA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/jquery": {
       "version": "3.5.34",
@@ -12837,15 +12841,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/jose": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "prettier": "@openmfp/config-prettier",
   "dependencies": {
+    "@jmespath-community/jmespath": "^1.3.0",
     "@luigi-project/plugin-auth-oauth2": "^2.27.0",
-    "jmespath": "^0.16.0",
     "jwt-decode": "^4.0.0",
     "lodash.isequal": "^4.5.0",
     "lodash.ismatch": "^4.4.0",
@@ -70,7 +70,6 @@
     "@fundamental-ngx/ui5-webcomponents": "0.63.0",
     "@openmfp/config-prettier": "0.9.2",
     "@openmfp/eslint-config-typescript": "0.7.11",
-    "@types/jmespath": "0.15.2",
     "@types/lodash": "4.17.25",
     "@types/node": "24.13.3",
     "@typescript-eslint/eslint-plugin": "8.66.0",

--- a/projects/lib/src/lib/utilities/jmespath.spec.ts
+++ b/projects/lib/src/lib/utilities/jmespath.spec.ts
@@ -1,5 +1,75 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { matchesJMESPath } from './jmespath';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { matchesJMESPath, transformLegacyBacktickLiterals } from './jmespath';
+
+describe('transformLegacyBacktickLiterals', () => {
+  it('should return expression unchanged when no backticks present', () => {
+    expect(transformLegacyBacktickLiterals('a.b == c')).toBe('a.b == c');
+  });
+
+  it('should wrap unquoted string in quotes', () => {
+    expect(transformLegacyBacktickLiterals('a == `admin`')).toBe(
+      'a == `"admin"`',
+    );
+  });
+
+  it('should not modify already-quoted strings', () => {
+    expect(transformLegacyBacktickLiterals('a == `"admin"`')).toBe(
+      'a == `"admin"`',
+    );
+  });
+
+  it('should not modify boolean literals', () => {
+    expect(transformLegacyBacktickLiterals('a == `true`')).toBe('a == `true`');
+    expect(transformLegacyBacktickLiterals('a == `false`')).toBe(
+      'a == `false`',
+    );
+  });
+
+  it('should not modify null literal', () => {
+    expect(transformLegacyBacktickLiterals('a == `null`')).toBe('a == `null`');
+  });
+
+  it('should not modify number literals', () => {
+    expect(transformLegacyBacktickLiterals('a == `123`')).toBe('a == `123`');
+    expect(transformLegacyBacktickLiterals('a == `-3.14`')).toBe(
+      'a == `-3.14`',
+    );
+  });
+
+  it('should not modify array literals', () => {
+    expect(transformLegacyBacktickLiterals('a == `[1,2,3]`')).toBe(
+      'a == `[1,2,3]`',
+    );
+  });
+
+  it('should not modify object literals', () => {
+    expect(transformLegacyBacktickLiterals('a == `{"key":"val"}`')).toBe(
+      'a == `{"key":"val"}`',
+    );
+  });
+
+  it('should handle multiple backtick literals in one expression', () => {
+    expect(
+      transformLegacyBacktickLiterals('type == `admin` && role == `editor`'),
+    ).toBe('type == `"admin"` && role == `"editor"`');
+  });
+
+  it('should handle mixed valid and invalid literals', () => {
+    expect(
+      transformLegacyBacktickLiterals('type == `admin` && count == `5`'),
+    ).toBe('type == `"admin"` && count == `5`');
+  });
+
+  it('should handle empty backtick content', () => {
+    expect(transformLegacyBacktickLiterals('a == ``')).toBe('a == `""`');
+  });
+
+  it('should escape special characters when wrapping', () => {
+    expect(transformLegacyBacktickLiterals('a == `he said "hi"`')).toBe(
+      'a == `"he said \\"hi\\""`',
+    );
+  });
+});
 
 describe('matchesJMESPath', () => {
   afterEach(() => {
@@ -9,7 +79,8 @@ describe('matchesJMESPath', () => {
   it('should return true for no query', () => {
     expect(matchesJMESPath({}, '')).toEqual(true);
   });
-  it('should return true for error and log a warning', () => {
+
+  it('should return false for error and log a warning', () => {
     console.warn = vi.fn();
     expect(matchesJMESPath({}, 'invalid@query')).toEqual(false);
     expect(console.warn).toHaveBeenCalled();
@@ -17,6 +88,24 @@ describe('matchesJMESPath', () => {
 
   it('should evaluate using JMESPath', () => {
     expect(matchesJMESPath({ a: true, b: 'test' }, 'a')).toEqual(true);
+  });
+
+  it('should handle legacy backtick literals via shim', () => {
+    expect(
+      matchesJMESPath(
+        { entityContext: { type: 'admin' } },
+        'entityContext.type == `admin`',
+      ),
+    ).toEqual(true);
+  });
+
+  it('should handle legacy backtick with non-matching value', () => {
+    expect(
+      matchesJMESPath(
+        { entityContext: { type: 'user' } },
+        'entityContext.type == `admin`',
+      ),
+    ).toEqual(false);
   });
 
   it('should return true if we match the context for a non-existing key', () => {
@@ -28,8 +117,8 @@ describe('matchesJMESPath', () => {
             component: {},
           },
         },
-        'entityContext.component.annotations."example.com/application-selector" == null'
-      )
+        'entityContext.component.annotations."example.com/application-selector" == null',
+      ),
     ).toEqual(true);
     expect(console.warn).not.toHaveBeenCalled();
   });
@@ -41,8 +130,8 @@ describe('matchesJMESPath', () => {
         {
           entityContext: { component: { tags: null } },
         },
-        'contains(entityContext.component.tags, "template")'
-      )
+        'contains(entityContext.component.tags, "template")',
+      ),
     ).toEqual(false);
     expect(console.warn).toHaveBeenCalled();
   });

--- a/projects/lib/src/lib/utilities/jmespath.ts
+++ b/projects/lib/src/lib/utilities/jmespath.ts
@@ -1,21 +1,61 @@
-import { search } from 'jmespath';
+import { search } from '@jmespath-community/jmespath';
 
-/**
- * Evaluates the JMESPath expression on the context and returns true if the result is true, otherwise false
- * @param context The context to evaluate
- * @param jmesPathExpression The JMESPath expression to evaluate
- * @returns true if the result of the JMESPath expression is true, otherwise (or if there was an exception while matching with JMESPath) false
- * */
+const BACKTICK_LITERAL_REGEX = /`((?:[^`\\]|\\.)*)`/g;
+const warnedExpressions = new Set<string>();
+
+function isValidJSON(str: string): boolean {
+  if (str === '') return false;
+  try {
+    JSON.parse(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function transformLegacyBacktickLiterals(expression: string): string {
+  if (!expression.includes('`')) {
+    return expression;
+  }
+
+  let transformed = false;
+
+  const result = expression.replace(
+    BACKTICK_LITERAL_REGEX,
+    (match, content: string) => {
+      if (isValidJSON(content)) {
+        return match;
+      }
+      transformed = true;
+      return '`' + JSON.stringify(content) + '`';
+    },
+  );
+
+  if (transformed && !warnedExpressions.has(expression)) {
+    warnedExpressions.add(expression);
+    console.warn(
+      `[JMESPath Migration] Legacy backtick literal detected and auto-converted.\n` +
+        `  Original:    ${expression}\n` +
+        `  Transformed: ${result}\n` +
+        `  Please update your expression to use proper JSON literals (e.g., \`"value"\` instead of \`value\`).`,
+    );
+  }
+
+  return result;
+}
+
 export function matchesJMESPath(
   context: object,
-  jmesPathExpression: string
+  jmesPathExpression: string,
 ): boolean {
   if (!jmesPathExpression) {
     return true;
   }
 
   try {
-    return search(context, jmesPathExpression) === true;
+    const normalizedExpression =
+      transformLegacyBacktickLiterals(jmesPathExpression);
+    return search(context as any, normalizedExpression) === true;
   } catch (e) {
     logJMESException(context, jmesPathExpression, e);
     return false;
@@ -25,7 +65,7 @@ export function matchesJMESPath(
 function logJMESException(
   context: object,
   jmesPathExpression: string,
-  error: unknown
+  error: unknown,
 ): void {
   console.warn(
     'Error while evaluating JMESPath expression.',
@@ -44,6 +84,6 @@ function logJMESException(
     '\n',
     'Exception: ',
     '\n',
-    error
+    error,
   );
 }


### PR DESCRIPTION
## Summary

- Replace unmaintained `jmespath@0.16.0` (last published Jan 2022) with actively maintained `@jmespath-community/jmespath@1.3.0`
- Remove `@types/jmespath` devDependency (community fork has built-in TypeScript types)
- Add backwards-compatible shim (`transformLegacyBacktickLiterals`) that auto-converts legacy backtick syntax so downstream consumers don't need immediate changes
- Deprecation warning logged once per unique legacy expression to guide migration

## Breaking Change Mitigation

The community fork requires valid JSON inside backtick literals (`` `"admin"` `` instead of `` `admin` ``). The shim transparently handles this conversion at runtime, preserving full backwards compatibility. A console warning nudges consumers to update their expressions over time.

## Test plan

- [ ] All existing tests pass without modification (validates backwards compatibility)
- [ ] New unit tests for `transformLegacyBacktickLiterals` cover: no backticks, unquoted strings, valid JSON passthrough, multiple literals, special characters
- [ ] `context.spec.ts` test with legacy `` `admin` `` syntax passes via the shim
- [ ] Library builds without TypeScript errors
- [ ] Branch coverage remains above 90% threshold

## Links

- [DXPFRAME-2504: Replace outdated dependencies](https://sap.atlassian.net/browse/DXPFRAME-2504)
- PR-#694: fix: replace outdated lodash.ismatch and lodash.isequal with inline utilities